### PR TITLE
add from_shape methods to jlarray and jltensor

### DIFF
--- a/include/xtensor-julia/jlarray.hpp
+++ b/include/xtensor-julia/jlarray.hpp
@@ -101,6 +101,9 @@ namespace xt
         explicit jlarray(const shape_type& shape, const_reference value);
         jlarray(jl_array_t* jl);
 
+        template <class S = shape_type>
+        static jlarray from_shape(S&& shape);
+
         jlarray(const self_type&);
         self_type& operator=(const self_type&);
 
@@ -252,6 +255,15 @@ namespace xt
     {
         init_from_julia();
     }
+
+    template <class T>
+    template <class S>
+    inline jlarray<T> jlarray<T>::from_shape(S&& shape)
+    {
+        shape_type shp = xtl::forward_sequence<shape_type>(shape);
+        return jlarray<T>(std::move(shp));
+    }
+
     //@}
 
     /**

--- a/include/xtensor-julia/jltensor.hpp
+++ b/include/xtensor-julia/jltensor.hpp
@@ -95,6 +95,9 @@ namespace xt
         explicit jltensor(const shape_type& shape, const_reference value);
         jltensor(jl_array_t* jl);
 
+        template <class S = shape_type>
+        static jltensor from_shape(S&& shape);
+
         jltensor(const self_type&);
         self_type& operator=(const self_type&);
 
@@ -201,6 +204,14 @@ namespace xt
         : base_type(jl)
     {
         init_from_julia();
+    }
+
+    template <class T, std::size_t N>
+    template <class S>
+    inline jltensor<T, N> jltensor<T, N>::from_shape(S&& shape)
+    {
+        auto shp = xtl::forward_sequence<shape_type>(shape);
+        return self_type(shp);
     }
     //@}
 

--- a/test/test_jlarray.cpp
+++ b/test/test_jlarray.cpp
@@ -162,4 +162,12 @@ namespace xt
         jlarray<int> a;
         EXPECT_EQ(0, a());
     }
+
+    TEST(jlarray, from_shape)
+    {
+        auto tens = jlarray<int>::from_shape({5, 4});
+        EXPECT_EQ(tens.shape()[0], 5);
+        EXPECT_EQ(tens.shape()[1], 4);
+        EXPECT_EQ(tens.size(), 20);
+    }
 }

--- a/test/test_jltensor.cpp
+++ b/test/test_jltensor.cpp
@@ -164,4 +164,11 @@ namespace xt
         EXPECT_EQ(0, a());
     }
 
+    TEST(jltensor, from_shape)
+    {
+        auto tens = jltensor<int, 2>::from_shape({5, 5});
+        EXPECT_EQ(tens.shape()[0], 5);
+        EXPECT_EQ(tens.shape()[1], 5);
+        EXPECT_EQ(tens.size(), 25);
+    }
 }


### PR DESCRIPTION
This is necessary for the upcoming blog post, because xtensor's `ones_like` requires this to be implemented.